### PR TITLE
add +active-users

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,11 +1,5 @@
 VERSION 0.6
 
-REQUIRE:
-    COMMAND
-    ARG argName
-    ARG argValue
-    RUN if [ -z "$argValue" ]; then echo "Argument '$argName' is required"; exit 1; fi
-
 INSTALL_DIND:
     COMMAND
     COPY +install-dind-script/install-dind.sh /tmp/install-dind.sh

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,11 @@
 VERSION 0.6
 
+REQUIRE:
+    COMMAND
+    ARG argName
+    ARG argValue
+    RUN if [ -z "$argValue" ]; then echo "Argument '$argName' is required"; exit 1; fi
+
 INSTALL_DIND:
     COMMAND
     COPY +install-dind-script/install-dind.sh /tmp/install-dind.sh

--- a/billing/Earthfile
+++ b/billing/Earthfile
@@ -4,7 +4,6 @@ FROM alpine/git:2.36.3
 
 # Estimates monthly active users of a GIT remote repo, based on past commits
 active-users:
-  ARG --required repoUrl
-  RUN git clone --bare --filter=blob:none $repoUrl repo;
+  RUN --secret repoUrl git clone --bare --filter=blob:none $repoUrl repo;
   RUN cd repo; \
       git --no-pager log -s --format="%ae" --since=30.days | grep -v @users.noreply.github.com | sort | uniq -c | awk '$1 >= 3 {print $0}' | wc -l

--- a/billing/Earthfile
+++ b/billing/Earthfile
@@ -4,8 +4,7 @@ FROM alpine/git:2.36.3
 
 # Estimates monthly active users of a GIT remote repo, based on past commits
 active-users:
-  ARG repoUrl
-  DO ../+REQUIRE --argName repoUrl --argValue $repoUrl
+  ARG --required repoUrl
   RUN git clone --bare --filter=blob:none $repoUrl repo;
   RUN cd repo; \
       git --no-pager log -s --format="%ae" --since=30.days | grep -v @users.noreply.github.com | sort | uniq -c | awk '$1 >= 3 {print $0}' | wc -l

--- a/billing/Earthfile
+++ b/billing/Earthfile
@@ -4,9 +4,8 @@ FROM alpine/git:2.36.3
 
 # Estimates monthly active users of a GIT remote repo, based on past commits
 active-users:
-  LOCALLY
   ARG repoUrl
-  RUN test $repoUrl
+  DO ../+REQUIRE --argName repoUrl --argValue $repoUrl
   RUN git clone --bare --filter=blob:none $repoUrl repo;
   RUN cd repo; \
       git --no-pager log -s --format="%ae" --since=30.days | grep -v @users.noreply.github.com | sort | uniq -c | awk '$1 >= 3 {print $0}' | wc -l

--- a/billing/Earthfile
+++ b/billing/Earthfile
@@ -1,0 +1,12 @@
+VERSION 0.6
+
+FROM alpine/git:2.36.3
+
+# Estimates monthly active users of a GIT remote repo, based on past commits
+active-users:
+  LOCALLY
+  ARG repoUrl
+  RUN test $repoUrl
+  RUN git clone --bare --filter=blob:none $repoUrl repo;
+  RUN cd repo; \
+      git --no-pager log -s --format="%ae" --since=30.days | grep -v @users.noreply.github.com | sort | uniq -c | awk '$1 >= 3 {print $0}' | wc -l

--- a/billing/README.md
+++ b/billing/README.md
@@ -4,13 +4,13 @@ Estimates monthly active users of a GIT remote repo, based on past commits
 
 Usage: 
 ```
-earthly github.com/earthly/lib/billing+active-users --repoUrl
+earthly --secret repoUrl=<repoUrl> github.com/earthly/lib/billing+active-users
 ```
 
 ### Private repositories
-For private repositories use https URLs, and pass credentials within the URL:
+For private repositories use `https` URLs, and pass credentials within the URL:
 ```
-earthly github.com/earthly/lib/billing+active-users https://<user>@<password>/host/repo.git
+earthly --secret repoUrl=https://<user>@<password>/host/repo.git github.com/earthly/lib/billing+active-users 
 ```
 > Note:
 > For GitHub private repos you need to use a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instead of your password 

--- a/billing/README.md
+++ b/billing/README.md
@@ -1,0 +1,16 @@
+# Billing utilities
+## +active-users
+Estimates monthly active users of a GIT remote repo, based on past commits
+
+Usage: 
+```
+earthly github.com/earthly/lib/billing+active-users --repoUrl
+```
+
+### Private repositories
+For private repositories use https URLs, and pass credentials within the URL:
+```
+earthly github.com/earthly/lib/billing+active-users https://<user>@<password>/host/repo.git
+```
+> Note:
+> For GitHub private repos you need to use a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instead of your password 


### PR DESCRIPTION
Adds a target to estimate earthly active users given a git repo URL.

Usage:
```
earthly +active-users --repoUrl <url>
```
Example:
```
earthly github.com/earthly/lib/billing:nacho/active-users+active-users --repoUrl git@github.com:earthly/earthly.git
```
