### PR TITLE
Rust: Allow running non-cargo commands with caches mounted

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -14,15 +14,12 @@ CARGO:
     IF [ "$keep_fingerprints" = "false" ]
        DO +REMOVE_SOURCE_FINGERPRINTS
     END
-    RUN --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/registry \
-        --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/git \
-        --mount=type=cache,mode=0777,target=target \
-        cargo $args; \
-        if [ -n "$output" ]; then \
-          mkdir /earthly_lib_rust_temp; \
-          cd target; \
-          find . -type f -regextype posix-egrep -regex "./$output" -exec cp --parents \{\} /earthly_lib_rust_temp \; ; \
-        fi
+    DO +RUN_WITH_CACHE --command="cargo $args;
+        if [ -n \"$output\" ]; then
+          mkdir /earthly_lib_rust_temp;
+          cd target;
+          find . -type f -regextype posix-egrep -regex \"./$output\" -exec cp --parents \{\} /earthly_lib_rust_temp \; ;
+        fi"
     IF [ "$output" != "" ]
       RUN mkdir -p target; \
           mv /earthly_lib_rust_temp/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp" ;
@@ -50,3 +47,19 @@ get-stoml:
     RUN wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64; \
        chmod +x stoml
     SAVE ARTIFACT ./stoml stoml
+
+# RUN_WITH_CACHE runs the passed command with the CARGO caches mounted.
+# Arguments:
+#   - command (required): Command to run, can be any expression.
+#
+# This implementation is not expected to significantly change. Prefer using the
+# `CARGO` UDC if you can, so you can get future improvements transparently.
+RUN_WITH_CACHE:
+    COMMAND
+    ARG command
+    RUN --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/registry \
+    --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/git \
+    --mount=type=cache,mode=0777,target=target \
+    set -e; \
+    printf "Running:\n      $command\n"; \
+    eval $command


### PR DESCRIPTION
Refactor the innards of `CARGO` into `RUN_WITH_CACHE` and use the latter from the former.

`CARGO` will be more full featured and should be preferred if possible.

Note that this adds `set -e` which was previously missing from `CARGO`.