### PR TITLE
global caches & cargo-sweep

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -3,12 +3,12 @@ VERSION --global-cache 0.7
 # CARGO runs the cargo command "cargo $args".
 # This UDC should be thread safe. Parallel builds of targets using it should be free of race conditions.
 # Arguments:
-#   - args: Cargo subcommand and its arguments. Required
-#   - keep_fingerprints (false): Do not remove source packages fingerprints. Use only when source packages have been COPYed with --keep-ts option
-#   - sweep_days (4): Number of days to retain target build artifacts in cache
+#   - args: Cargo subcommand and its arguments. Required.
+#   - keep_fingerprints (false): Do not remove source packages fingerprints. Use only when source packages have been COPYed with --keep-ts option.
+#   - sweep_days (4): The UDC uses cargo-sweep to clean build artifacts that haven't been accessed for this number of days.
 #   - output: Regex to match the files within the target folder to be copied from the cache to the caller filesystem (image layers).
 #     Use this argument when you want to SAVE an ARTIFACT from the target folder (mounted cache), always trying to minimize the total size of the copied fileset.
-#     For example --output="release/[^\./]+" would keep all the files in /target/release that don't have any extension
+#     For example --output="release/[^\./]+" would keep all the files in /target/release that don't have any extension.
 CARGO:
     COMMAND
     ARG --required args
@@ -38,7 +38,7 @@ CARGO:
     END
 
 # REMOVE_SOURCE_FINGERPRINTS removes the Cargo fingerprint folders of the source packages.
-# This guarantees Cargo compiles the packages when COPY commands of the source folders have a static timestamp (see --keep-ts)
+# This guarantees Cargo compiles the packages when COPY commands of the source folders have a static timestamp (see --keep-ts).
 REMOVE_SOURCE_FINGERPRINTS:
     COMMAND
     COPY +get-tomljson/tomljson /tmp/tomljson
@@ -54,7 +54,7 @@ REMOVE_SOURCE_FINGERPRINTS:
         done
       done"
 
-# get-tomljson gets the portable tomljson binary
+# get-tomljson gets the portable tomljson binary.
 get-tomljson:
     FROM alpine:3.18.3
     ARG USERARCH
@@ -64,14 +64,14 @@ get-tomljson:
         chmod +x tomljson
     SAVE ARTIFACT ./tomljson tomljson
 
-# get-jq gets the portable jq binary
+# get-jq gets the portable jq binary.
 get-jq:
     FROM alpine:3.18.3
     RUN apk add jq;
     ARG jq=$(which jq)
     SAVE ARTIFACT $jq jq
 
-# INSTALL_CARGO_SWEEP installs cargo-sweep if it doesn't exist already
+# INSTALL_CARGO_SWEEP installs cargo-sweep if it doesn't exist already.
 INSTALL_CARGO_SWEEP:
     COMMAND
     DO +RUN_WITH_CACHE --command="set -e;
@@ -83,16 +83,14 @@ INSTALL_CARGO_SWEEP:
 # Arguments:
 #   - command (required): Command to run, can be any expression.
 #
-# This implementation is not expected to significantly change. Prefer using the
-# `CARGO` UDC if you can, so you can get future improvements transparently.
+# This implementation is not expected to significantly change. Prefer using the `CARGO` UDC if you can, so you can get future improvements transparently.
 RUN_WITH_CACHE:
     COMMAND
     ARG command
     ARG EARTHLY_TARGET_PROJECT_NO_TAG
     ARG CACHE_ID="${EARTHLY_TARGET_PROJECT_NO_TAG}#earthly-cargo-cache"
     # $ORIGINAL_CARGO_HOME/bin will contain the cargo and rust binaries, as well as the installed crates.
-    # We save it to reset it back at the end
-    # This location is presumed to be in the calling target layers filesystem rather than in other mount cache
+    # We save it to reset it back at the end. This location is presumed to be in the calling target layers filesystem rather than in other mount cache.
     ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
     # Make sure that crates installed though this UDC are stored in the original cargo home, and not in the cargo home within the mount cache.
     # This way, if BK garbage-collects them, the build is not broken

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION --global-cache 0.7
 
 # CARGO runs the cargo command "cargo $args".
 # This UDC should be thread safe. Parallel builds of targets using it should be free of race conditions.
@@ -19,20 +19,17 @@ CARGO:
        DO +REMOVE_SOURCE_FINGERPRINTS
     END
     DO +INSTALL_CARGO_SWEEP
-    RUN --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/registry \
-        --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/git \
-        --mount=type=cache,mode=0777,target=/tmp/earthly \
-        --mount=type=cache,mode=0777,target=target \
-        echo "Running cargo $args" ; \
-        cargo $args; \
-        if [ -n "$output" ]; then \
-          echo "Copying output files" ; \
-          mkdir /earthly_lib_rust_temp; \
-          cd target; \
-          find . -type f -regextype posix-egrep -regex "./$output" -exec cp --parents \{\} /earthly_lib_rust_temp \; ; \
-        fi; \
-        echo "Running cargo sweep -dry-run -r -t $sweep_days" ; \
-        /tmp/earthly/cargo-sweep sweep --dry-run -r -t $sweep_days;
+    DO +RUN_WITH_CACHE --command="echo \"Running cargo $args\" ;
+        cargo $args;
+        if [ -n \"$output\" ]; then
+          echo \"Copying output files\" ;
+          mkdir /earthly_lib_rust_temp;
+          cd target;
+          find . -type f -regextype posix-egrep -regex \"./$output\" -exec cp --parents \{\} /earthly_lib_rust_temp \; ;
+          cd ..;
+        fi;
+        echo \"Running cargo sweep -dry-run -r -t $sweep_days\" ;
+        /tmp/earthly/cargo-sweep sweep --dry-run -r -t $sweep_days;"
     IF [ "$output" != "" ]
       RUN mkdir -p target; \
           mv /earthly_lib_rust_temp/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp" ;
@@ -43,35 +40,48 @@ CARGO:
 REMOVE_SOURCE_FINGERPRINTS:
     COMMAND
     DO +INSTALL_STOML
-    RUN --mount=type=cache,mode=0777,target=/tmp/earthly \
-    --mount=type=cache,mode=0777,sharing=shared,target=target \
-      set -e; \
-      source_libs=$(find . -name Cargo.toml -exec bash -c '/tmp/earthly/stoml {} package.name; printf "\n"' \;) ;\
-      fingerprint_folders=$(find target -name .fingerprint) ; \
-      for fingerprint_folder in $fingerprint_folders; do \
-        cd $fingerprint_folder; \
-        for source_lib in $source_libs; do \
-          find . -maxdepth 1 -regex "\./$source_lib-[^-]+" -exec rm -rf {} \; ;\
-        done \
-      done
+    DO +RUN_WITH_CACHE --command="set -e;
+      source_libs=$(find . -name Cargo.toml -exec bash -c '/tmp/earthly/stoml {} package.name; printf "\n"' \;) ;
+      fingerprint_folders=$(find target -name .fingerprint) ;
+      for fingerprint_folder in $fingerprint_folders; do
+        cd $fingerprint_folder;
+        for source_lib in $source_libs; do
+          find . -maxdepth 1 -regex \"\./$source_lib-[^-]+\" -exec rm -rf {} \; ;
+        done
+      done"
 
-# INSTALL_STOML installs, https://github.com/freshautomations/stoml in earthly helper cache at /tmp/earthly/stoml, if it doesn't exist already
+# INSTALL_STOML installs https://github.com/freshautomations/stoml in earthly helper cache at /tmp/earthly/stoml, if it doesn't exist already
 INSTALL_STOML:
     COMMAND
-    RUN --mount=type=cache,mode=0777,target=/tmp/earthly \
-        set -e; \
-        if [ ! -f /tmp/earthly/stoml ]; then \
-          cd /tmp/earthly/; \
-          wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64; \
-          chmod +x stoml; \
-        fi;
+    DO +RUN_WITH_CACHE --command="set -e;
+        if [ ! -f /tmp/earthly/stoml ]; then
+          cd /tmp/earthly/;
+          wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64;
+          chmod +x stoml;
+        fi;"
 
 # INSTALL_CARGO_SWEEP installs cargo-sweep in earthly helper cache at: /tmp/earthly/cargo-sweep, if it doesn't exist already
 INSTALL_CARGO_SWEEP:
     COMMAND
-    RUN --mount=type=cache,mode=0777,target=/tmp/earthly \
-        set -e; \
-        if [ ! -f /tmp/earthly/cargo-sweep ]; then \
-          cargo install cargo-sweep; \
-          cp $CARGO_HOME/bin/cargo-sweep /tmp/earthly/; \
-        fi;
+    DO +RUN_WITH_CACHE --command="set -e;
+        if [ ! -f /tmp/earthly/cargo-sweep ]; then
+          cargo install cargo-sweep;
+          cp $CARGO_HOME/bin/cargo-sweep /tmp/earthly/;
+        fi;"
+
+# RUN_WITH_CACHE runs the passed command with the CARGO caches mounted.
+# Arguments:
+#   - command (required): Command to run, can be any expression.
+#
+# This implementation is not expected to significantly change. Prefer using the
+# `CARGO` UDC if you can, so you can get future improvements transparently.
+RUN_WITH_CACHE:
+    COMMAND
+    ARG command
+    RUN --mount=type=cache,mode=0777,id="earthly-cargo-home-registry",sharing=shared,target=$CARGO_HOME/registry \
+        --mount=type=cache,mode=0777,id="earthly-cargo-home-git",sharing=shared,target=$CARGO_HOME/git \
+        --mount=type=cache,mode=0777,id="earthly-cargo-deps",sharing=shared,target=/tmp/earthly \
+        --mount=type=cache,mode=0777,target=target \
+    set -e; \
+    printf "Running:\n      $command\n"; \
+    eval $command

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -19,7 +19,8 @@ CARGO:
        DO +REMOVE_SOURCE_FINGERPRINTS
     END
     DO +INSTALL_CARGO_SWEEP
-    DO +RUN_WITH_CACHE --command="echo \"Running cargo $args\" ;
+    DO +RUN_WITH_CACHE --command="set -e;
+        echo \"Running cargo $args\" ;
         cargo $args;
         if [ -n \"$output\" ]; then
           echo \"Copying output files\" ;
@@ -88,7 +89,7 @@ INSTALL_CARGO_SWEEP:
 # This implementation is not expected to significantly change. Prefer using the `CARGO` UDC if you can, so you can get future improvements transparently.
 RUN_WITH_CACHE:
     COMMAND
-    ARG command
+    ARG --required command
     ARG EARTHLY_TARGET_PROJECT_NO_TAG
     ARG CACHE_ID="${EARTHLY_TARGET_PROJECT_NO_TAG}#earthly-cargo-cache"
     # $ORIGINAL_CARGO_HOME/bin will contain the cargo and rust binaries, as well as the installed crates.

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -32,7 +32,7 @@ CARGO:
           find . -type f -regextype posix-egrep -regex "./$output" -exec cp --parents \{\} /earthly_lib_rust_temp \; ; \
         fi; \
         echo "Running cargo sweep -dry-run -r -t $sweep_days" ; \
-        /tmp/earthly/cargo-sweep sweep --dry-run -r -i -t $sweep_days;
+        /tmp/earthly/cargo-sweep sweep --dry-run -r -t $sweep_days;
     IF [ "$output" != "" ]
       RUN mkdir -p target; \
           mv /earthly_lib_rust_temp/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp" ;

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -94,6 +94,7 @@ RUN_WITH_CACHE:
     # $ORIGINAL_CARGO_HOME/bin will contain the cargo and rust binaries, as well as the installed crates.
     # We save it to reset it back at the end. This location is presumed to be in the calling target layers filesystem rather than in other mount cache.
     ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
+    ARG ORIGINAL_CARGO_INSTALL_ROOT=$CARGO_INSTALL_ROOT
     # Make sure that crates installed though this UDC are stored in the original cargo home, and not in the cargo home within the mount cache.
     # This way, if BK garbage-collects them, the build is not broken
     ENV CARGO_INSTALL_ROOT=$ORIGINAL_CARGO_HOME
@@ -107,3 +108,4 @@ RUN_WITH_CACHE:
     printf "Running:\n      $command\n"; \
     eval $command
     ENV CARGO_HOME=$ORIGINAL_CARGO_HOME
+    ENV CARGO_INSTALL_ROOT=$ORIGINAL_CARGO_INSTALL_ROOT

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -86,10 +86,13 @@ INSTALL_CARGO_SWEEP:
 RUN_WITH_CACHE:
     COMMAND
     ARG command
+    ARG EARTHLY_TARGET_PROJECT_NO_TAG
+    ARG CACHE_ID="${EARTHLY_TARGET_PROJECT_NO_TAG}#earthly-cargo-cache"
     ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
     ENV CARGO_INSTALL_ROOT=$CARGO_HOME
     ENV CARGO_HOME="/earthly/.cargo"
-    RUN --mount=type=cache,mode=0777,id="earthly-cargo-cache",sharing=shared,target=/earthly \
+    RUN echo $CACHE_ID
+    RUN --mount=type=cache,mode=0777,id=$CACHE_ID,sharing=shared,target=/earthly \
         --mount=type=cache,mode=0777,target=target \
     set -e; \
     mkdir -p $CARGO_HOME; \

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -31,7 +31,7 @@ CARGO:
           cd target; \
           find . -type f -regextype posix-egrep -regex "./$output" -exec cp --parents \{\} /earthly_lib_rust_temp \; ; \
         fi; \
-        echo "Running cargo sweep -dry-run -r -i -t $sweep_days" ; \
+        echo "Running cargo sweep -dry-run -r -t $sweep_days" ; \
         /tmp/earthly/cargo-sweep sweep --dry-run -r -i -t $sweep_days;
     IF [ "$output" != "" ]
       RUN mkdir -p target; \

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -28,8 +28,10 @@ CARGO:
           find . -type f -regextype posix-egrep -regex \"./$output\" -exec cp --parents \{\} /earthly_lib_rust_temp \; ;
           cd ..;
         fi;
-        echo \"Running cargo sweep -dry-run -r -t $sweep_days\" ;
-        /tmp/earthly/cargo-sweep sweep --dry-run -r -t $sweep_days;"
+        echo \"Running cargo sweep -r -t $sweep_days\" ;
+        /tmp/earthly/cargo-sweep sweep -r -t $sweep_days;
+        echo \"Running cargo sweep -r -i\" ;
+        /tmp/earthly/cargo-sweep sweep -r -i;"
     IF [ "$output" != "" ]
       RUN mkdir -p target; \
           mv /earthly_lib_rust_temp/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp" ;

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -23,7 +23,7 @@ CARGO:
         cargo $args;
         if [ -n \"$output\" ]; then
           echo \"Copying output files\" ;
-          mkdir /earthly_lib_rust_temp;
+          mkdir -p /earthly_lib_rust_temp;
           cd target;
           find . -type f -regextype posix-egrep -regex \"./$output\" -exec cp --parents \{\} /earthly_lib_rust_temp \; ;
           cd ..;
@@ -41,9 +41,10 @@ CARGO:
 # This guarantees Cargo compiles the packages when COPY commands of the source folders have a static timestamp (see --keep-ts)
 REMOVE_SOURCE_FINGERPRINTS:
     COMMAND
-    DO +INSTALL_STOML
+    COPY +get-tomljson/tomljson /tmp/tomljson
+    COPY +get-jq/jq /tmp/jq
     DO +RUN_WITH_CACHE --command="set -e;
-      source_libs=\$(find . -name Cargo.toml -exec bash -c '/earthly/bin/stoml {} package.name; printf \"\\n\"' \\;) ;
+      source_libs=\$(find . -name Cargo.toml -exec bash -c '/tmp/tomljson {} | jq -r .package.name; printf \"\\n\"' \\;) ;
       fingerprint_folders=\$(find target -name .fingerprint) ;
       echo \"deleting fingerprints:\";
       for fingerprint_folder in \$fingerprint_folders; do
@@ -53,15 +54,20 @@ REMOVE_SOURCE_FINGERPRINTS:
         done
       done"
 
-# INSTALL_STOML installs https://github.com/freshautomations/stoml in the cache at /earthly/bin/stoml, if it doesn't exist already
-INSTALL_STOML:
-    COMMAND
-    DO +RUN_WITH_CACHE --command="set -e;
-        if [ ! -f /earthly/bin/stoml ]; then
-          cd /earthly/bin;
-          wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64;
-          chmod +x stoml;
-        fi;"
+# get-tomljson gets the portable tomljson binary
+get-tomljson:
+    FROM alpine:3.18.3
+    RUN wget -O tomljson.tar.xz https://github.com/pelletier/go-toml/releases/download/v2.1.0/tomljson_2.1.0_linux_amd64.tar.xz; \
+        tar -xf tomljson.tar.xz; \
+        chmod +x tomljson
+    SAVE ARTIFACT ./tomljson tomljson
+
+# get-jq gets the portable jq binary
+get-jq:
+    FROM alpine:3.18.3
+    RUN apk add jq;
+    ARG jq=$(which jq)
+    SAVE ARTIFACT $jq jq
 
 # INSTALL_CARGO_SWEEP installs cargo-sweep if it doesn't exist already
 INSTALL_CARGO_SWEEP:

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -87,6 +87,7 @@ RUN_WITH_CACHE:
     COMMAND
     ARG command
     ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
+    ENV CARGO_INSTALL_ROOT=$CARGO_HOME
     ENV CARGO_HOME="/earthly/.cargo"
     RUN --mount=type=cache,mode=0777,id="earthly-cargo-cache",sharing=shared,target=/earthly \
         --mount=type=cache,mode=0777,target=target \

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -88,8 +88,14 @@ RUN_WITH_CACHE:
     ARG command
     ARG EARTHLY_TARGET_PROJECT_NO_TAG
     ARG CACHE_ID="${EARTHLY_TARGET_PROJECT_NO_TAG}#earthly-cargo-cache"
+    # $ORIGINAL_CARGO_HOME/bin will contain the cargo and rust binaries, as well as the installed crates.
+    # We save it to reset it back at the end
+    # This location is presumed to be in the calling target layers filesystem rather than in other mount cache
     ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
-    ENV CARGO_INSTALL_ROOT=$CARGO_HOME
+    # Make sure that crates installed though this UDC are stored in the original cargo home, and not in the cargo home within the mount cache.
+    # This way, if BK garbage-collects them, the build is not broken
+    ENV CARGO_INSTALL_ROOT=$ORIGINAL_CARGO_HOME
+    # We need $CARGO_HOME/.package-cache within the earthly shared-mount-cache, so cargo can properly synchronize parallel access to $CARGO_HOME resources.
     ENV CARGO_HOME="/earthly/.cargo"
     RUN echo $CACHE_ID
     RUN --mount=type=cache,mode=0777,id=$CACHE_ID,sharing=shared,target=/earthly \

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -29,9 +29,9 @@ CARGO:
           cd ..;
         fi;
         echo \"Running cargo sweep -r -t $sweep_days\" ;
-        /tmp/earthly/cargo-sweep sweep -r -t $sweep_days;
+        cargo sweep -r -t $sweep_days;
         echo \"Running cargo sweep -r -i\" ;
-        /tmp/earthly/cargo-sweep sweep -r -i;"
+        cargo sweep -r -i;"
     IF [ "$output" != "" ]
       RUN mkdir -p target; \
           mv /earthly_lib_rust_temp/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp" ;
@@ -43,32 +43,32 @@ REMOVE_SOURCE_FINGERPRINTS:
     COMMAND
     DO +INSTALL_STOML
     DO +RUN_WITH_CACHE --command="set -e;
-      source_libs=$(find . -name Cargo.toml -exec bash -c '/tmp/earthly/stoml {} package.name; printf "\n"' \;) ;
-      fingerprint_folders=$(find target -name .fingerprint) ;
-      for fingerprint_folder in $fingerprint_folders; do
-        cd $fingerprint_folder;
-        for source_lib in $source_libs; do
-          find . -maxdepth 1 -regex \"\./$source_lib-[^-]+\" -exec rm -rf {} \; ;
+      source_libs=\$(find . -name Cargo.toml -exec bash -c '/earthly/bin/stoml {} package.name; printf \"\\n\"' \\;) ;
+      fingerprint_folders=\$(find target -name .fingerprint) ;
+      echo \"deleting fingerprints:\";
+      for fingerprint_folder in \$fingerprint_folders; do
+        cd \$fingerprint_folder;
+        for source_lib in \$source_libs; do
+          find . -maxdepth 1 -regex \"\./\$source_lib-[^-]+\" -exec bash -c 'readlink -f {}; rm -rf {}' \; ;
         done
       done"
 
-# INSTALL_STOML installs https://github.com/freshautomations/stoml in earthly helper cache at /tmp/earthly/stoml, if it doesn't exist already
+# INSTALL_STOML installs https://github.com/freshautomations/stoml in the cache at /earthly/bin/stoml, if it doesn't exist already
 INSTALL_STOML:
     COMMAND
     DO +RUN_WITH_CACHE --command="set -e;
-        if [ ! -f /tmp/earthly/stoml ]; then
-          cd /tmp/earthly/;
+        if [ ! -f /earthly/bin/stoml ]; then
+          cd /earthly/bin;
           wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64;
           chmod +x stoml;
         fi;"
 
-# INSTALL_CARGO_SWEEP installs cargo-sweep in earthly helper cache at: /tmp/earthly/cargo-sweep, if it doesn't exist already
+# INSTALL_CARGO_SWEEP installs cargo-sweep if it doesn't exist already
 INSTALL_CARGO_SWEEP:
     COMMAND
     DO +RUN_WITH_CACHE --command="set -e;
-        if [ ! -f /tmp/earthly/cargo-sweep ]; then
+        if [ ! -f \$CARGO_HOME/bin/cargo-sweep ]; then
           cargo install cargo-sweep;
-          cp $CARGO_HOME/bin/cargo-sweep /tmp/earthly/;
         fi;"
 
 # RUN_WITH_CACHE runs the passed command with the CARGO caches mounted.
@@ -80,10 +80,13 @@ INSTALL_CARGO_SWEEP:
 RUN_WITH_CACHE:
     COMMAND
     ARG command
-    RUN --mount=type=cache,mode=0777,id="earthly-cargo-home-registry",sharing=shared,target=$CARGO_HOME/registry \
-        --mount=type=cache,mode=0777,id="earthly-cargo-home-git",sharing=shared,target=$CARGO_HOME/git \
-        --mount=type=cache,mode=0777,id="earthly-cargo-deps",sharing=shared,target=/tmp/earthly \
+    ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
+    ENV CARGO_HOME="/earthly/.cargo"
+    RUN --mount=type=cache,mode=0777,id="earthly-cargo-cache",sharing=shared,target=/earthly \
         --mount=type=cache,mode=0777,target=target \
     set -e; \
+    mkdir -p $CARGO_HOME; \
+    mkdir -p /earthly/bin ;\
     printf "Running:\n      $command\n"; \
     eval $command
+    ENV CARGO_HOME=$ORIGINAL_CARGO_HOME

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -74,7 +74,7 @@ INSTALL_CARGO_SWEEP:
     COMMAND
     DO +RUN_WITH_CACHE --command="set -e;
         if [ ! -f \$CARGO_HOME/bin/cargo-sweep ]; then
-          cargo install cargo-sweep;
+          cargo install cargo-sweep --root \$CARGO_HOME;
         fi;"
 
 # RUN_WITH_CACHE runs the passed command with the CARGO caches mounted.

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -2,7 +2,9 @@ VERSION 0.7
 
 # CARGO caches the cargo command "cargo $cargo_args"
 # Arguments:
-#   - args (required): Cargo subcommand and its arguments
+#   - args: Cargo subcommand and its arguments. Required
+#   - keep_fingerprints (false): Do no remove source packages fingerprints. Use only when source packages have been COPYed with --keep-ts option
+#   - sweep_days (4): Number of days to retain target build artifacts in cache
 #   - output: Regex to match the files within the target folder to be copied from the cache to the caller filesystem (image layers).
 #     Use this argument when you want to SAVE an ARTIFACT from the target folder (mounted cache), always trying to minimize the total size of the copied fileset.
 #     For example --output="release/[^\./]+" would keep all the files in /target/release that don't have any extension
@@ -10,19 +12,26 @@ CARGO:
     COMMAND
     ARG --required args
     ARG keep_fingerprints=false
+    ARG sweep_days=4
     ARG output
     IF [ "$keep_fingerprints" = "false" ]
        DO +REMOVE_SOURCE_FINGERPRINTS
     END
+    DO +INSTALL_CARGO_SWEEP
     RUN --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/registry \
         --mount=type=cache,mode=0777,sharing=shared,target=$CARGO_HOME/git \
+        --mount=type=cache,mode=0777,target=/tmp/earthly \
         --mount=type=cache,mode=0777,target=target \
+        echo "Running cargo $args" ; \
         cargo $args; \
         if [ -n "$output" ]; then \
+          echo "Copying output files" ; \
           mkdir /earthly_lib_rust_temp; \
           cd target; \
           find . -type f -regextype posix-egrep -regex "./$output" -exec cp --parents \{\} /earthly_lib_rust_temp \; ; \
-        fi
+        fi; \
+        echo "Running cargo sweep -r -t $sweep_days" ; \
+        /tmp/earthly/cargo-sweep sweep -r -t $sweep_days;
     IF [ "$output" != "" ]
       RUN mkdir -p target; \
           mv /earthly_lib_rust_temp/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp" ;
@@ -32,10 +41,11 @@ CARGO:
 # This guarantees Cargo compiles the packages when COPY commands of the source folders have a static timestamp (see --keep-ts)
 REMOVE_SOURCE_FINGERPRINTS:
     COMMAND
-    COPY +get-stoml/stoml /tmp/stoml
-    ARG source_libs=$(find . -name Cargo.toml -exec bash -c '/tmp/stoml {} package.name; printf "\n"' \\;)
-    RUN --mount=type=cache,mode=0777,sharing=shared,target=target \
-      find target -name .fingerprint; \
+    DO +INSTALL_STOML
+    RUN --mount=type=cache,mode=0777,target=/tmp/earthly \
+    --mount=type=cache,mode=0777,sharing=shared,target=target \
+      set -e; \
+      source_libs=$(find . -name Cargo.toml -exec bash -c '/tmp/earthly/stoml {} package.name; printf "\n"' \;) ;\
       fingerprint_folders=$(find target -name .fingerprint) ; \
       for fingerprint_folder in $fingerprint_folders; do \
         cd $fingerprint_folder; \
@@ -44,9 +54,23 @@ REMOVE_SOURCE_FINGERPRINTS:
         done \
       done
 
-# get-stoml gets the portable stoml binary
-get-stoml:
-    FROM alpine:3.18.3
-    RUN wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64; \
-       chmod +x stoml
-    SAVE ARTIFACT ./stoml stoml
+# INSTALL_STOML installs, https://github.com/freshautomations/stoml in earthly helper cache at /tmp/earthly/stoml, if it doesn't exist already
+INSTALL_STOML:
+    COMMAND
+    RUN --mount=type=cache,mode=0777,target=/tmp/earthly \
+        set -e; \
+        if [ ! -f /tmp/earthly/stoml ]; then \
+          cd /tmp/earthly/; \
+          wget -O stoml https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64; \
+          chmod +x stoml; \
+        fi;
+
+# INSTALL_CARGO_SWEEP installs cargo-sweep in earthly helper cache at: /tmp/earthly/cargo-sweep, if it doesn't exist already
+INSTALL_CARGO_SWEEP:
+    COMMAND
+    RUN --mount=type=cache,mode=0777,target=/tmp/earthly \
+        set -e; \
+        if [ ! -f /tmp/earthly/cargo-sweep ]; then \
+          cargo install cargo-sweep; \
+          cp $CARGO_HOME/bin/cargo-sweep /tmp/earthly/; \
+        fi;

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -57,7 +57,9 @@ REMOVE_SOURCE_FINGERPRINTS:
 # get-tomljson gets the portable tomljson binary
 get-tomljson:
     FROM alpine:3.18.3
-    RUN wget -O tomljson.tar.xz https://github.com/pelletier/go-toml/releases/download/v2.1.0/tomljson_2.1.0_linux_amd64.tar.xz; \
+    ARG USERARCH
+    ARG version=2.1.0
+    RUN wget -O tomljson.tar.xz https://github.com/pelletier/go-toml/releases/download/v${version}/tomljson_${version}_linux_${USERARCH}.tar.xz; \
         tar -xf tomljson.tar.xz; \
         chmod +x tomljson
     SAVE ARTIFACT ./tomljson tomljson

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -96,7 +96,6 @@ RUN_WITH_CACHE:
         --mount=type=cache,mode=0777,target=target \
     set -e; \
     mkdir -p $CARGO_HOME; \
-    mkdir -p /earthly/bin ;\
     printf "Running:\n      $command\n"; \
     eval $command
     ENV CARGO_HOME=$ORIGINAL_CARGO_HOME

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -44,7 +44,7 @@ REMOVE_SOURCE_FINGERPRINTS:
     COPY +get-tomljson/tomljson /tmp/tomljson
     COPY +get-jq/jq /tmp/jq
     DO +RUN_WITH_CACHE --command="set -e;
-      source_libs=\$(find . -name Cargo.toml -exec bash -c '/tmp/tomljson {} | jq -r .package.name; printf \"\\n\"' \\;) ;
+      source_libs=\$(find . -name Cargo.toml -exec bash -c '/tmp/tomljson {} | /tmp/jq -r .package.name; printf \"\\n\"' \\;) ;
       fingerprint_folders=\$(find target -name .fingerprint) ;
       echo \"deleting fingerprints:\";
       for fingerprint_folder in \$fingerprint_folders; do
@@ -62,14 +62,16 @@ get-tomljson:
     RUN wget -O tomljson.tar.xz https://github.com/pelletier/go-toml/releases/download/v${version}/tomljson_${version}_linux_${USERARCH}.tar.xz; \
         tar -xf tomljson.tar.xz; \
         chmod +x tomljson
-    SAVE ARTIFACT ./tomljson tomljson
+    SAVE ARTIFACT tomljson
 
 # get-jq gets the portable jq binary.
 get-jq:
     FROM alpine:3.18.3
-    RUN apk add jq;
-    ARG jq=$(which jq)
-    SAVE ARTIFACT $jq jq
+    ARG USERARCH
+    ARG version=1.7
+    RUN wget -O jq https://github.com/jqlang/jq/releases/download/jq-${version}/jq-linux-${USERARCH}; \
+        chmod +x jq
+    SAVE ARTIFACT jq
 
 # INSTALL_CARGO_SWEEP installs cargo-sweep if it doesn't exist already.
 INSTALL_CARGO_SWEEP:

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -45,15 +45,15 @@ REMOVE_SOURCE_FINGERPRINTS:
     COPY +get-tomljson/tomljson /tmp/tomljson
     COPY +get-jq/jq /tmp/jq
     DO +RUN_WITH_CACHE --command="set -e;
-      source_libs=\$(find . -name Cargo.toml -exec bash -c '/tmp/tomljson {} | /tmp/jq -r .package.name; printf \"\\n\"' \\;) ;
-      fingerprint_folders=\$(find target -name .fingerprint) ;
-      echo \"deleting fingerprints:\";
-      for fingerprint_folder in \$fingerprint_folders; do
-        cd \$fingerprint_folder;
-        for source_lib in \$source_libs; do
-          find . -maxdepth 1 -regex \"\./\$source_lib-[^-]+\" -exec bash -c 'readlink -f {}; rm -rf {}' \; ;
-        done
-      done"
+        source_libs=\$(find . -name Cargo.toml -exec bash -c '/tmp/tomljson {} | /tmp/jq -r .package.name; printf \"\\n\"' \\;) ;
+        fingerprint_folders=\$(find target -name .fingerprint) ;
+        echo \"deleting fingerprints:\";
+        for fingerprint_folder in \$fingerprint_folders; do
+          cd \$fingerprint_folder;
+          for source_lib in \$source_libs; do
+            find . -maxdepth 1 -regex \"\./\$source_lib-[^-]+\" -exec bash -c 'readlink -f {}; rm -rf {}' \; ;
+          done
+        done"
 
 # get-tomljson gets the portable tomljson binary.
 get-tomljson:
@@ -104,9 +104,9 @@ RUN_WITH_CACHE:
     RUN echo $CACHE_ID
     RUN --mount=type=cache,mode=0777,id=$CACHE_ID,sharing=shared,target=/earthly \
         --mount=type=cache,mode=0777,target=target \
-    set -e; \
-    mkdir -p $CARGO_HOME; \
-    printf "Running:\n      $command\n"; \
-    eval $command
+        set -e; \
+        mkdir -p $CARGO_HOME; \
+        printf "Running:\n      $command\n"; \
+        eval $command
     ENV CARGO_HOME=$ORIGINAL_CARGO_HOME
     ENV CARGO_INSTALL_ROOT=$ORIGINAL_CARGO_INSTALL_ROOT

--- a/rust/README.md
+++ b/rust/README.md
@@ -8,8 +8,9 @@ This UDC runs the cargo command `cargo $args` caching the contents of `$CARGO_HO
 
 ### Usage
 
-First, import the UDC up in your Earthfile:
+First, import the UDC up in your Earthfile. Also, the UDC makes use of global caches, so make sure to enable the feature flag as follows:
 ```earthfile
+VERSION --global-cache 0.7
 IMPORT github.com/earthly/lib/rust:<version/commit> AS rust
 ```
 
@@ -32,6 +33,9 @@ Do not remove source packages fingerprints. Use only when source packages have b
 Cargo caches compilations of packages in `target` folder based on their last modification timestamps. 
 
 By default, this UDC removes the fingerprints of the packages found in the source code, to force their recompilation and work even when the Earthly `COPY` commands used overwrote the timestamps.
+
+#### `sweep_days (4)`
+The UDC uses [cargo-sweep](https://github.com/holmgr/cargo-sweep) to clean build artifacts that haven't been accessed for this number of days.
 
 #### `output`
 Regex to match the files within the target folder to be copied from the cache to the caller filesystem (image layers). 

--- a/rust/README.md
+++ b/rust/README.md
@@ -8,9 +8,9 @@ This UDC runs the cargo command `cargo $args` caching the contents of `$CARGO_HO
 
 ### Usage
 
-First, import the UDC up in your Earthfile. Also, the UDC makes use of global caches, so make sure to enable the feature flag as follows:
+First, import the UDC up in your Earthfile:
 ```earthfile
-VERSION --global-cache 0.7
+VERSION 0.7
 IMPORT github.com/earthly/lib/rust:<version/commit> AS rust
 ```
 


### PR DESCRIPTION
## Summary
This PR:
- Runs cargo sweep after the user cargo sub-command
- Introduces @ijc `RUN_WITH_CACHE` [UDC](https://github.com/earthly/lib/pull/19) 
- Caches `$CARGO_HOME` is a non-locking global cache (shared across all Earthfiles). This significantly reduces cache size

### On global cache
In order to make the new global cache work with `sharing=shared` mode (that allows parallel builds to access its contents), I had to make sure that `$CARGO_HOME/.package-cache` was also being stored in the cache, since this the file used by Cargo as a lock to synchronize the access to `$CARGO_HOME` from parallel builds.

The simplest way I found to achieve this was by temporarily changing the whole `$CARGO_HOME` location to a folder within the cache, while running the same bin/cargo program.
