### PR TITLE
Add with_docker

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -74,6 +74,7 @@ CARGO:
 #   - command (required): Command to run, can be any expression.
 #   - cargo_home_cache_id: ID of the cargo home cache mount. By default: $CARGO_HOME_CACHE_ID as exported by +INIT
 #   - target_cache_id: ID of the target cache mount. By default: ${CARGO_HOME_CACHE_ID}#${EARTHLY_TARGET_NAME}
+#   - with_docker: Runs the command within a WITH DOCKER element parametrized with this value
 #
 RUN_WITH_CACHE:
     COMMAND
@@ -82,6 +83,7 @@ RUN_WITH_CACHE:
     ARG EARTHLY_TARGET_NAME
     ARG cargo_home_cache_id = $CARGO_HOME_CACHE_ID
     ARG target_cache_id="${CARGO_HOME_CACHE_ID}#${EARTHLY_TARGET_NAME}"
+    ARG with_docker
     # Save to restore at the end.
     ARG ORIGINAL_CARGO_HOME=$CARGO_HOME
     ARG ORIGINAL_CARGO_INSTALL_ROOT=$CARGO_INSTALL_ROOT
@@ -91,12 +93,23 @@ RUN_WITH_CACHE:
     # We change $CARGO_HOME while keeping $ORIGINAL_CARGO_HOME/bin directory in the path. This way, the Cargo binary is still accessible and the whole $CARGO_HOME is within the global cache
     # ($CARGO_HOME/.package-cache has to be in the cache so Cargo can properly synchronize parallel access to $CARGO_HOME resources).
     ENV CARGO_HOME="/tmp/earthly/.cargo"
-    RUN --mount=type=cache,mode=0777,id=$cargo_home_cache_id,sharing=shared,target=$CARGO_HOME \
+    IF [ -n "$with_docker" ]
+      WITH DOCKER $with_docker
+        RUN --mount=type=cache,mode=0777,id=$cargo_home_cache_id,sharing=shared,target=$CARGO_HOME \
+            --mount=type=cache,mode=0777,id=$target_cache_id,sharing=locked,target=target \
+            set -e; \
+            mkdir -p $CARGO_HOME; \
+            printf "Running:\n      $command\n"; \
+            eval $command
+      END
+    ELSE
+      RUN --mount=type=cache,mode=0777,id=$cargo_home_cache_id,sharing=shared,target=$CARGO_HOME \
         --mount=type=cache,mode=0777,id=$target_cache_id,sharing=locked,target=target \
         set -e; \
         mkdir -p $CARGO_HOME; \
         printf "Running:\n      $command\n"; \
         eval $command
+    END
     ENV CARGO_HOME=$ORIGINAL_CARGO_HOME
     ENV CARGO_INSTALL_ROOT=$ORIGINAL_CARGO_INSTALL_ROOT
     ENV TARGET_CACHE_ID=$target_cache_id


### PR DESCRIPTION
Lets running commands within a `WITH DOCKER` clause, with the cargo caches mounted.

Fixes https://github.com/earthly/lib/issues/34