### PR TITLE
Support active user calculation for self-hosted repos

### DIFF
--- a/billing/Earthfile
+++ b/billing/Earthfile
@@ -4,11 +4,23 @@ FROM alpine/git:2.36.3
 
 # Estimates monthly active users of a GIT remote repo, based on past commits
 active-users:
-
-  RUN mkdir ~/.ssh; \
-      ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts; \
-      ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
-  RUN --no-cache --ssh --secret repoUrl git clone --bare --filter=blob:none $repoUrl repo;
+  RUN apk add --no-cache python3
+  RUN echo "
+from urllib.parse import urlsplit
+import sys
+p = urlsplit(sys.argv[1])
+if p.scheme == 'ssh':
+  with open('/tmp/.host', 'w') as f:
+    f.write(p.hostname)
+  with open('/tmp/.port', 'w') as f:
+    f.write(str(p.port or 22))
+" > parse.py
+  RUN --no-cache --ssh --secret repoUrl python3 parse.py "$repoUrl" && \
+      # don't scan if SSH isn't actually used; some environments may actively block it
+      if [ -f /tmp/.host ]; then \
+        ssh-keyscan -t rsa -p "$(cat /tmp/.port)" "$(cat /tmp/.host)" > /etc/ssh/ssh_known_hosts; \
+      fi && \
+      git clone --bare --filter=blob:none $repoUrl repo;
   RUN --no-cache cd repo; \
       activeUsers=$(git --no-pager log -s --format="%ae" --since=30.days | grep -v @users.noreply.github.com | sort | uniq -c | awk '$1 >= 3 {print $0}' | wc -l); \
       echo ""; \


### PR DESCRIPTION
This dynamically adds SSH keys based on the URL passed, allowing clones to work with providers other than github and gitlab.

This was surprisingly complicated; I believe the combination of the entire URL being passed as a secret, which necessitates `--no-cache`, resulted in my preferred implementations not working (I suspect due to https://github.com/earthly/earthly/issues/2593).  I assumed keeping the 'interface' intact was paramount (given that it's publicly documented); inlining all usage of the secret was the only thing that worked consistently.

You're welcome to close this, borrow from it for your own preferred implementation, etc.  I at least wanted it to work for myself, so figured I'd share it.

Potential fix for #49 