### PR TITLE
Fix --output in some cases (#53)

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -109,7 +109,12 @@ COPY_OUTPUT:
             cd ..;  \
         fi;
     RUN mkdir -p target; \
-        mv $TMP_FOLDER/* target 2>/dev/null || echo "no files found within ./target matching the provided output regexp";
+        if [ "$(find "$TMP_FOLDER" -type f -printf . | wc -c)" -eq 0 ]; then  \
+            echo "no files found within ./target matching the provided output regexp"; \
+        else \
+            cp -ruT "$TMP_FOLDER" target;  \
+            rm -rf "$TMP_FOLDER";  \
+        fi;
 
 # CROSS runs the [cross](https://github.com/cross-rs/cross) command "cross $args --target $target".
 # Notice that in order to run this function, +INIT must be called first.


### PR DESCRIPTION
Currently, when --output is used multiple times on the same directory, the underlying command which copies the output can fail with a misleading error message. Even if your regular expression matches a file in the target directory, you're presented with:

"no files found within ./target matching the provided output regexp"

If the "mv" command's stderr is printed, it shows:

"mv: inter-device move failed: '/tmp/earthly/lib/rust/release' to 'target/release'; unable to remove target: Directory not empty"

Since "mv" doesn't handle existing directories the way we may want here, let's use "cp -ruT" to overlay the files into the target directory (regardless of what's already present there) and then remove the temporary directory.